### PR TITLE
Remove print

### DIFF
--- a/yandex_checkout/domain/models/payment_data/response/credit_card.py
+++ b/yandex_checkout/domain/models/payment_data/response/credit_card.py
@@ -55,7 +55,6 @@ class CreditCard(BaseObject):
 
     @card_type.setter
     def card_type(self, value):
-        print(value)
         if value in CardType.__dict__.values():
             self.__card_type = value
         else:


### PR DESCRIPTION
This produces unformatted data in stdout.
Generally it would be better to use logging module with DEBUG level.
But in this case it seems to be an unnecessary statement.