### PR TITLE
Поправил возможность передачи customer в виде словаря

### DIFF
--- a/test/unit/test_receipt.py
+++ b/test/unit/test_receipt.py
@@ -143,3 +143,18 @@ class TestReceipt(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             receipt_item.amount = 'invalid amount'
+
+    def test_receipt_customer(self):
+        receipt = Receipt({
+            'customer': {
+                'email': 'foo@bar.egg',
+                'inn': '4815162342',
+            }
+        })
+        self.assertEqual({
+            'customer': {
+                'email': 'foo@bar.egg',
+                'inn': '4815162342',
+            },
+            'email': 'foo@bar.egg',
+        }, dict(receipt))

--- a/yandex_checkout/domain/models/receipt.py
+++ b/yandex_checkout/domain/models/receipt.py
@@ -19,7 +19,9 @@ class Receipt(BaseObject):
 
     @customer.setter
     def customer(self, value):
-        if isinstance(value, ReceiptCustomer):
+        if isinstance(value, dict):
+            self.__customer = ReceiptCustomer(value)
+        elif isinstance(value, ReceiptCustomer):
             self.__customer = value
         else:
             raise TypeError('Invalid customer value type')


### PR DESCRIPTION
Привет! Следующий код выдаст ошибку `TypeError: Invalid customer value type`
```
from yandex_checkout import Payment

Payment.create({
...
    'receipt': {
        'customer': {
            'email': 'foo@bar.egg',
            ...
        }
    }
...
})
```