### PR TITLE
Add CUP card type

### DIFF
--- a/yandex_checkout/domain/models/payment_data/card_type.py
+++ b/yandex_checkout/domain/models/payment_data/card_type.py
@@ -9,6 +9,7 @@ class CardType:
     VISA = 'Visa'
     MIR = 'MIR'
     UNION_PAY = 'UnionPay'
+    CUP = 'CUP'
     JCB = 'JCB'
     AMERICAN_EXPRESS = 'AmericanExpress'
     UNKNOWN = 'Unknown'


### PR DESCRIPTION
Got "Invalid card_type value" error recently.
Here is a fixup.