### PR TITLE
Enable timeout in client request

### DIFF
--- a/test/unit/test_client_timeout.py
+++ b/test/unit/test_client_timeout.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from requests.exceptions import ConnectTimeout
+
+from yandex_checkout.client import ApiClient
+from yandex_checkout.configuration import Configuration
+from yandex_checkout.domain.common.http_verb import HttpVerb
+from yandex_checkout.domain.common.user_agent import Version
+from yandex_checkout.domain.common.request_object import RequestObject
+
+# Requests to this URL should always fail with a connection timeout (nothing
+# listening on that port)
+TARPIT = "http://10.255.255.1"
+
+
+class TestClient(unittest.TestCase):
+    def setUp(self):
+        Configuration.configure(
+            account_id="test_account_id",
+            secret_key="test_secret_key",
+            timeout=1,
+        )
+        Configuration.agent_framework = Version(
+            "Yandex.Money.Framework", "0.0.1"
+        )
+        Configuration.agent_cms = Version("Yandex.Money.Cms", "0.0.2")
+        Configuration.agent_module = Version("Yandex.Money.Module", "0.0.3")
+        self.client = ApiClient()
+        self.client.endpoint = TARPIT
+
+    def test_request_timout(self):
+        request_args = (
+            HttpVerb.GET,
+            "/path",
+            RequestObject(),
+            {"header": "header"},
+        )
+        self.assertRaises(ConnectTimeout, self.client.request, *request_args)

--- a/yandex_checkout/client.py
+++ b/yandex_checkout/client.py
@@ -54,7 +54,8 @@ class ApiClient:
                                        self.endpoint + path,
                                        params=query_params,
                                        headers=request_headers,
-                                       json=body)
+                                       json=body,
+                                       timeout=self.timeout)
         return raw_response
 
     def get_session(self):


### PR DESCRIPTION
В конфигурации присутсвует параметр `timeout`, но он не используется при выполнении непостредственно запроса.

Если в качестве эндпойнта указать любой блекхол в сети, то запрос повиснет вне зависимости от параметра `timeout`. 

В реальной обстановке с запросом может случится что-то подобное и приложение, очевидно, повиснет. На первый взгляд кажется, что достаточно уже существующую переменную добавить в запрос `requests`, но не могу казать что я смотрел  весь код. 