### PR TITLE
Fix decimal error

### DIFF
--- a/yandex_checkout/domain/models/amount.py
+++ b/yandex_checkout/domain/models/amount.py
@@ -21,7 +21,7 @@ class Amount(BaseObject):
 
     @value.setter
     def value(self, value):
-        self.__value = Decimal(round(float(value), 2))
+        self.__value = Decimal(value)
 
     @property
     def currency(self):


### PR DESCRIPTION
В decimal лучше передавать строку напрямую. 

Приведение к float приводит к вот такому значению Decimal("1.0300000000000000266453525910037569701671600341796875")
вместо Decimal("1.03")

В стандартном https://docs.python.org/2/library/decimal.html#quick-start-tutorial есть пример для 3.14